### PR TITLE
Modified Dockerfile to Work Better with the Mounted Volume Workflow

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,15 +15,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
   && rm -rf /var/lib/apt/lists/*
 
-# Where we'll put the source
-WORKDIR /opt
+# Set the working directory where the mounted repo will be
+WORKDIR /workspace
 
-# Copy the source code to the container
-COPY . /opt/imperial-purple/
-
-# Navigate to the project directory and build
-WORKDIR /opt/imperial-purple
-RUN N=$(nproc) && echo "Building with N=${N} jobs..." && make -j"${N}"
-
-# Default to an interactive shell (optional)
+# Default to an interactive shell
 CMD ["/bin/bash"]


### PR DESCRIPTION
## Description
<!-- Detail the changes made, why they were made, and any important context. -->
The original Dockerfile used to make its own copy of the working directory so that when you mounted a volume it was a duplicate. This was confusing. This PR changes things so that there is no default directory, so that when you mount a volume it's the only one in the container.

## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, closes #2222." Remove this section if not applicable.-->

Closes #1 
